### PR TITLE
Remove space from .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -177,5 +177,5 @@ Layout/SpaceInsideBlockBraces:
 Style/BracesAroundHashParameters:
   Enabled: false
   
- Style/WhileUntilDo:
+Style/WhileUntilDo:
   Enabled: false 


### PR DESCRIPTION
Remove an errant space character in .rubocop.yml making it invalid yaml.